### PR TITLE
Clientside addon for exporting

### DIFF
--- a/@ocap/addons/ocap_client/CfgEventHandlers.hpp
+++ b/@ocap/addons/ocap_client/CfgEventHandlers.hpp
@@ -1,0 +1,14 @@
+// Uncomment this for testing in singleplayer
+// #define DEBUG_MODE
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMPInterrupt {
+        OCAP = "call OCAP_client_fnc_onPause";
+    };
+
+#ifdef DEBUG_MODE
+    class RscDisplayInterrupt  {
+        OCAP = "call OCAP_client_fnc_onPause";
+    };
+#endif
+};

--- a/@ocap/addons/ocap_client/CfgFunctions.hpp
+++ b/@ocap/addons/ocap_client/CfgFunctions.hpp
@@ -1,0 +1,8 @@
+class CfgFunctions {
+    class OCAP_Client {
+        class fucntions {
+            file = "ocap_client\functions";
+            class onPause {};
+        };
+    };
+};

--- a/@ocap/addons/ocap_client/config.cpp
+++ b/@ocap/addons/ocap_client/config.cpp
@@ -1,0 +1,18 @@
+class CfgPatches {
+    class OCAP_Client {
+        name = "OCAP Client";
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] = {"cba_xeh", "cba_diagnostic"};
+        authors[] = {"BaerMitUmlaut"};
+        author = "BaerMitUmlaut";
+        authorUrl = "https://github.com/mistergoodson/OCAP";
+        version = "1.0.0";
+        versionStr = "1.0.0";
+        versionAr[] = {1, 0, 0};
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgFunctions.hpp"

--- a/@ocap/addons/ocap_client/functions/fn_onPause.sqf
+++ b/@ocap/addons/ocap_client/functions/fn_onPause.sqf
@@ -1,0 +1,37 @@
+/*
+    Author: BaerMitUmlaut
+
+    Description:
+    Adds the save button to the escape menu for admins in multiplayer.
+
+    Parameters:
+    _this select 0: DISPLAY - Escape menu display.
+*/
+params ["_display"];
+
+// Filter non admins, allow SP for debug mode
+if !(serverCommandAvailable "#logout" || {!isMultiplayer}) exitWith {};
+
+private _debugConsole = _display displayCtrl 13184;
+
+// First, hide the useless GUI editor button
+private _buttonGUIEditor = _debugConsole controlsGroupCtrl 13292;
+_buttonGUIEditor ctrlShow false;
+_buttonGUIEditor ctrlEnable false;
+
+// Next, create the OCAP export button where the GUI editor button was
+private _buttonOCAPExport = _display ctrlCreate ["RscButtonMenu", -1, _debugConsole];
+_buttonOCAPExport ctrlSetText "OCAP EXPORT";
+_buttonOCAPExport ctrlSetPosition (ctrlPosition _buttonGUIEditor);
+_buttonOCAPExport ctrlSetBackgroundColor [
+    profilenamespace getvariable ["GUI_BCG_RGB_R", 0.77],
+    profilenamespace getvariable ["GUI_BCG_RGB_G", 0.51],
+    profilenamespace getvariable ["GUI_BCG_RGB_B", 0.08],
+    profilenamespace getvariable ["GUI_BCG_RGB_A", 0.8]
+];
+_buttonOCAPExport ctrlCommit 0;
+
+// And finally make it do stuff
+_buttonOCAPExport ctrlAddEventHandler ["onButtonClick", {
+    [] remoteExecCall ["ocap_fnc_exportData", 2];
+}];


### PR DESCRIPTION
This adds a small clientside addon which adds a button in the escape menu to comfortably export the AAR data. Needs testing as I don't have an OCAP setup available, requires CBA.

Screenshot:
![](http://i.imgur.com/J2IoSqj.jpg)
