### PR TITLE
Add ACE3 lastSourceOfDamage

### DIFF
--- a/@ocap/addons/ocap/functions/fn_eh_killed.sqf
+++ b/@ocap/addons/ocap/functions/fn_eh_killed.sqf
@@ -24,10 +24,15 @@ if (_victim getVariable ["ocap_exclude", false]) exitWith {}; // Just in case
 
 _victimId = _victim getVariable "ocap_id";
 
-// If killer is null, then unit likely killed by fire/collision/exploding vehicle
 _eventData = [ocap_captureFrameNo, "killed", _victimId, ["null"], -1];
+
+// If killer is null, then unit likely killed by fire/collision/exploding vehicle/ACE3
+private _aceLastSourceOfDamage = _victim getVariable ["ace_medical_lastDamageSource", objNull];
+if (!isNull _aceLastSourceOfDamage) then {
+	_killer = _aceLastSourceOfDamage;
+};
+
 if (!isNull _killer) then {
-	
 	_killerInfo = [];
 	if (_killer isKindOf "CAManBase") then {
 		_killerInfo = [

--- a/@ocap/addons/ocap/functions/fn_eh_killed.sqf
+++ b/@ocap/addons/ocap/functions/fn_eh_killed.sqf
@@ -17,14 +17,14 @@
 	_this select 1: OBJECT - Killer
 */
 
-_victim = _this select 0;
-_killer = _this select 1;
+private _victim = _this select 0;
+private _killer = _this select 1;
 
 if (_victim getVariable ["ocap_exclude", false]) exitWith {}; // Just in case
 
-_victimId = _victim getVariable "ocap_id";
+private _victimId = _victim getVariable "ocap_id";
 
-_eventData = [ocap_captureFrameNo, "killed", _victimId, ["null"], -1];
+private _eventData = [ocap_captureFrameNo, "killed", _victimId, ["null"], -1];
 
 // If killer is null, then unit likely killed by fire/collision/exploding vehicle/ACE3
 private _aceLastSourceOfDamage = _victim getVariable ["ace_medical_lastDamageSource", objNull];
@@ -33,7 +33,7 @@ if (!isNull _aceLastSourceOfDamage) then {
 };
 
 if (!isNull _killer) then {
-	_killerInfo = [];
+	private _killerInfo = [];
 	if (_killer isKindOf "CAManBase") then {
 		_killerInfo = [
 			_killer getVariable "ocap_id",


### PR DESCRIPTION
When merged this pull request will:
- add the last registered source of damage (e.g. when a player bleeds out, the kill will be credited to the last player/AI to hit him)
- add `private` declarations to private variables
