### PR TITLE
little fix

### DIFF
--- a/gameserver/@ocap/addons/ocap/functions/fn_atEndOfArray.sqf
+++ b/gameserver/@ocap/addons/ocap/functions/fn_atEndOfArray.sqf
@@ -1,6 +1,5 @@
 
 // Returns true if given index is out of bounds for given array
-private _index = _this select 0;
-private _array = _this select 1;
 
-_index + 1 >= count _array
+params ["_index", "_array"];
+_index >= count _array


### PR DESCRIPTION
The check on the border was not working correctly.
Example:
``` sqf
_arr = [0, 1, 2, 3];
_cnt = count _arr; // 4
_index = 3;
_arr # _index; // 3 The index within the boundaries of the array.
_index + 1 >= count _array // true
3 + 1 >= 4
```
